### PR TITLE
cache emoji to prevent reloading them every time

### DIFF
--- a/src/emoji.rs
+++ b/src/emoji.rs
@@ -1,4 +1,6 @@
+use image::{load_from_memory_with_format, DynamicImage, ImageFormat};
 use rand::random;
+use std::collections::HashMap;
 
 const EMOJIS: [&[u8]; 3360] = [
     include_bytes!("../assets/emoji_pngs/1f004.png"),
@@ -3365,6 +3367,22 @@ const EMOJIS: [&[u8]; 3360] = [
 
 const EMOJIS_LEN: usize = EMOJIS.len();
 
-pub fn get_emoji() -> &'static [u8] {
-    unsafe { *EMOJIS.get_unchecked(random::<usize>() % EMOJIS_LEN) }
+pub struct EmojiCache {
+    emoji_cache: HashMap<usize, DynamicImage>,
+}
+
+impl EmojiCache {
+    pub fn new() -> EmojiCache {
+        EmojiCache {
+            emoji_cache: HashMap::new(),
+        }
+    }
+
+    pub fn get_emoji(&mut self) -> &DynamicImage {
+        let index = random::<usize>() % EMOJIS_LEN;
+        self.emoji_cache.entry(index).or_insert_with(|| {
+            let e = unsafe { EMOJIS.get_unchecked(index) };
+            load_from_memory_with_format(e, ImageFormat::Png).unwrap()
+        })
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub fn generate_image(
     save_progress: bool,
     path: &Path,
 ) -> Result<Vec<u8>, ImageError> {
+    let mut emoji_cache = emoji::EmojiCache::new();
     let orig = load_from_memory(image_buffer)?;
     let (width, height) = orig.dimensions();
     let orig = orig.to_bytes();
@@ -33,12 +34,11 @@ pub fn generate_image(
     let mut dist = sums_chunked(&orig, &new_img);
 
     for _ in 0..iterations {
-        let e = emoji::get_emoji();
+        let e = &emoji_cache.get_emoji();
         let w: u32 = random::<u32>() % width;
         let h: u32 = random::<u32>() % height;
-        let e = load_from_memory_with_format(e, ImageFormat::Png)?;
         let mut temp_img = new_img.clone();
-        overlay(&mut temp_img, &e, w, h);
+        overlay(&mut temp_img, &**e, w, h);
         let temp_dist = sums_chunked(&orig, &temp_img);
         if dist > temp_dist {
             new_img = temp_img;


### PR DESCRIPTION
cache loading emoijs from bytes to PNGs to speed up long running processes